### PR TITLE
Add license and expand documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+dist/
+*.egg-info/
+
+# OS-generated files
+.DS_Store
+Thumbs.db

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # codex-test
+
+## Overview
+
+This repository serves as a simple test project for Codex demo environments. It provides a small codebase used for testing collaborative workflows and automated review processes.
+
+## Installation
+
+Clone the repository and install any required dependencies:
+
+```bash
+git clone <repository-url>
+cd codex-test
+```
+
+This project currently has no mandatory dependencies.
+
+## Usage
+
+Use this repository to experiment with Git, pull requests, and review tools. You can modify files, commit changes, and explore development workflows.
+
+## Contributing
+
+Contributions are welcome. Fork the repository, create a feature branch, and open a pull request describing your changes.
+
+## License
+
+This project is licensed under the terms of the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- elaborate README with overview, installation, usage, contributing, and license notes
- add MIT license text
- include `.gitignore` for temporary files

## Testing
- `git status --short`